### PR TITLE
fix token_blackbox_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ migration/sqlbindata_test.go
 configuration/confbindata.go
 wit/witservice
 account/tenant
+test/generated
 test/service
 test/token/oauth
 test/login

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,8 @@ generate-minimock: deps $(MINIMOCK_BIN) ## Generate Minimock sources. Only neces
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/application/service.NotificationService,github.com/fabric8-services/fabric8-auth/application/service.WITService,github.com/fabric8-services/fabric8-auth/application/service.ClusterService,github.com/fabric8-services/fabric8-auth/application/service.AuthenticationProviderService -o ./test/service/ -s ".go"
 	@-mkdir -p test/token/oauth
 	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authentication/provider.IdentityProvider -o ./test/token/oauth/ -s ".go"
+	@-mkdir -p test/generated/authorization/token/manager
+	@$(MINIMOCK_BIN) -i github.com/fabric8-services/fabric8-auth/authorization/token/manager.TokenManagerConfiguration -o ./test/generated/authorization/token/manager/ -s ".go"
 
 .PHONY: build
 ## Build server and client.

--- a/authentication/provider/service/authentication_provider_service_blackbox_test.go
+++ b/authentication/provider/service/authentication_provider_service_blackbox_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fabric8-services/fabric8-auth/rest"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/fabric8-services/fabric8-auth/rest"
 
 	"github.com/fabric8-services/fabric8-auth/app"
 	"github.com/fabric8-services/fabric8-auth/application/service/factory"

--- a/authorization/token/manager/token_manager_test.go
+++ b/authorization/token/manager/token_manager_test.go
@@ -2,12 +2,13 @@ package manager_test
 
 import (
 	"context"
-	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
 	"testing"
 	"time"
+
+	"github.com/fabric8-services/fabric8-auth/authorization/token/manager"
 
 	"github.com/fabric8-services/fabric8-auth/authentication/account"
 	"github.com/fabric8-services/fabric8-auth/authentication/account/repository"
@@ -175,7 +176,7 @@ func (s *TestTokenSuite) checkGenerateRPTTokenForIdentity() {
 	s.assertIntClaim(rptClaims, "nbf", 0)
 	s.assertClaim(rptClaims, "iss", "https://auth.openshift.io")
 	s.assertClaim(rptClaims, "aud", "https://openshift.io")
-	s.assertClaim(rptClaims, "typ", "Bearer")
+	s.assertClaim(rptClaims, "typ", "bearer")
 	s.assertClaim(rptClaims, "auth_time", iat)
 	s.assertClaim(rptClaims, "approved", !identity.User.Deprovisioned)
 	s.assertClaim(rptClaims, "sub", identity.ID.String())
@@ -219,7 +220,7 @@ func (s *TestTokenSuite) assertGeneratedToken(generatedToken *oauth2.Token, iden
 	s.assertIntClaim(accessToken, "nbf", 0)
 	s.assertClaim(accessToken, "iss", "https://auth.openshift.io")
 	s.assertClaim(accessToken, "aud", "https://openshift.io")
-	s.assertClaim(accessToken, "typ", "Bearer")
+	s.assertClaim(accessToken, "typ", "bearer")
 	s.assertClaim(accessToken, "auth_time", iat)
 	s.assertClaim(accessToken, "approved", !identity.User.Deprovisioned)
 	s.assertClaim(accessToken, "sub", identity.ID.String())

--- a/authorization/token/service/token_service.go
+++ b/authorization/token/service/token_service.go
@@ -386,6 +386,7 @@ func (s *tokenServiceImpl) ExchangeRefreshToken(ctx context.Context, accessToken
 	}
 	// if an RPT token is provided, then use it to obtain a new token with updated permission claims
 	if identity != nil && accessToken != "" {
+		// TODO: can't we just call s.Refresh(...) now?
 		refreshedAccessToken, err := s.Services().TokenService().Refresh(ctx, identity, accessToken)
 		if err != nil {
 			return nil, err

--- a/controller/login_end_to_end_blackbox_test.go
+++ b/controller/login_end_to_end_blackbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/fabric8-services/fabric8-auth/app"
 	account "github.com/fabric8-services/fabric8-auth/authentication/account/repository"
 	"github.com/fabric8-services/fabric8-auth/authentication/provider"
@@ -11,16 +12,12 @@ import (
 	"github.com/fabric8-services/fabric8-auth/client"
 	"github.com/fabric8-services/fabric8-auth/rest"
 
+	"strings"
+
 	testtoken "github.com/fabric8-services/fabric8-auth/test/token"
 	"github.com/goadesign/goa"
 	"github.com/stretchr/testify/assert"
-	"strings"
 
-	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
-	"github.com/fabric8-services/fabric8-auth/resource"
-	"github.com/goadesign/goa/uuid"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,6 +25,12 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/fabric8-services/fabric8-auth/gormtestsupport"
+	"github.com/fabric8-services/fabric8-auth/resource"
+	"github.com/goadesign/goa/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestServiceLoginBlackboxTest(t *testing.T) {
@@ -470,7 +473,7 @@ func (s *serviceLoginBlackBoxTest) serveOauthServer(rw http.ResponseWriter, req 
 		rw.Write([]byte(tokenResponse))
 
 	} else if req.URL.Path == "/api/profile" {
-		require.NotEqual(s.T(), "Bearer", req.Header.Get("authorization"))
+		require.NotEqual(s.T(), "bearer", req.Header.Get("authorization"))
 		userResponse := provider.IdentityProviderResponse{
 			Username:   s.identity.Username,
 			Subject:    s.identity.ID.String(),


### PR DESCRIPTION
- expect access and refresh token to be renewed
- expect type to be `bearer`
- expect failure if access token was signed by an unknown key

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
